### PR TITLE
Update Rust edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,33 @@ on:
       - main
 
 jobs:
-  ci:
-    name: CI on ${{ matrix.os }}
-    runs-on: ${{matrix.os}}
-    strategy:
-      matrix:
-        os: [ubuntu-24.04, windows-latest, macos-latest]
-
+  build:
+    name: Build
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@master
+        with:
+          lfs: true
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
+      - uses: Swatinem/rust-cache@v2
 
       - name: cargo build
         run: cargo build
+
+  check:
+    name: Check
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -39,35 +53,42 @@ jobs:
       fail-fast: false
 
     name: cargo-deny
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@main
+      - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          rust-version: "1.83.0"
+          rust-version: "1.85.0"
           log-level: error
           command: check
 
   publish-check:
     name: Publish Check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
       - uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@master
+      - uses: Swatinem/rust-cache@v2
       - run: cargo fetch
       - name: cargo publish
         run: cargo publish --dry-run
 
   typos:
     name: Typos
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: crate-ci/typos@master
 
   cargo-machete:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/checkout@v4
       - name: Machete
         uses: bnjbvr/cargo-machete@main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-fontawesome-icons"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/bircni/rust-fontawesome"
 description = "Get all usable Font Awesome icons."
 authors = ["bircni"]
@@ -18,7 +18,7 @@ anyhow = "1"
 convert_case = "0.7"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
-tera = { version = "1.20.0", default-features = false }
+tera = { version = "1.20", default-features = false }
 tokio = { version = "1.42", features = ["macros"] }
 
 [dev-dependencies]
@@ -28,15 +28,49 @@ egui_extras = { version = "0.31", features = ["http", "svg"] }
 rust-fontawesome-icons = { path = "." }
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "deny"
 deprecated = "warn"
+elided_lifetimes_in_paths = "warn"
+future_incompatible = { level = "warn", priority = -1 }
+nonstandard_style = { level = "warn", priority = -1 }
+rust_2018_idioms = { level = "warn", priority = -1 }
+rust_2021_prelude_collisions = "warn"
+semicolon_in_expressions_from_macros = "warn"
+trivial_numeric_casts = "warn"
+unsafe_op_in_unsafe_fn = "warn"                         # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
+unused_extern_crates = "warn"
+unused_import_braces = "warn"
+unused_lifetimes = "warn"
+trivial_casts = "allow"
+unused_qualifications = "allow"
+
+[workspace.lints.rustdoc]
+all = "warn"
+missing_crate_level_docs = "warn"
 
 [workspace.lints.clippy]
-restriction = "warn"
-complexity = "warn"
+all = "warn"
 correctness = "warn"
-nursery = "warn"
-pedantic = "warn"
-perf = "warn"
-style = "warn"
 suspicious = "warn"
+style = "warn"
+complexity = "warn"
+perf = "warn"
+pedantic = "warn"
+nursery = "warn"
+unwrap_used = "warn"
+expect_used = "warn"
+
+# Additional lints from https://rust-lang.github.io/rust-clippy/master/index.html?groups=restriction
+absolute_paths = "warn"
+allow_attributes = "warn"
+allow_attributes_without_reason = "warn"
+assertions_on_result_states = "warn"
+create_dir = "warn"
+clone_on_ref_ptr = "warn"
+missing_assert_message = "warn"
+panic_in_result_fn = "warn"
+shadow_reuse = "warn"
+str_to_string = "warn"
+todo = "warn"
+unimplemented = "warn"
+wildcard_enum_match_arm = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,16 +15,16 @@ std = []
 
 [build-dependencies]
 anyhow = "1"
-convert_case = "0.6.0"
+convert_case = "0.7"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 tera = { version = "1.20.0", default-features = false }
 tokio = { version = "1.42", features = ["macros"] }
 
 [dev-dependencies]
-eframe = "0.30"
-egui = "0.30"
-egui_extras = { version = "0.30", features = ["http", "svg"] }
+eframe = "0.31"
+egui = "0.31"
+egui_extras = { version = "0.31", features = ["http", "svg"] }
 rust-fontawesome-icons = { path = "." }
 
 [workspace.lints.rust]

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -16,3 +16,26 @@ impl From<Icon> for Cow<'static, str> {
         Cow::from(icon.url())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const FA_VERSION: &str = "6.7.2";
+    #[test]
+    fn test_display() {
+        assert_eq!(
+            Icon::RUST.to_string(),
+            "https://site-assets.fontawesome.com/releases/v6.7.2/svgs/brands/rust.svg"
+        );
+    }
+
+    #[test]
+    fn test_into_cow() {
+        let icon: Cow<'static, str> = Icon::RUST.into();
+        assert_eq!(
+            icon,
+            "https://site-assets.fontawesome.com/releases/v6.7.2/svgs/brands/rust.svg"
+        );
+    }
+}


### PR DESCRIPTION
Upgrade the Rust edition to 2024 and update various dependencies to their latest versions. Adjust CI configuration for improved compatibility and performance.